### PR TITLE
Make YouTube embeds HTTPS

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -218,7 +218,7 @@ projects A3-[MultiBot] and A8-[HumanoidSpace].</p>
 </div>
 <p>
     <a href="http://validator.w3.org/check?uri=referer"><img
-        src="https://www.w3.org/Icons/valid-html401"
+        src="http://www.w3.org/Icons/valid-html401"
         alt="Valid HTML 4.01 Transitional" height="31" width="88"></a>
   </p>
   

--- a/index.htm
+++ b/index.htm
@@ -96,8 +96,8 @@ all <a href="https://github.com/OctoMap/octomap/blob/devel/octomap/AUTHORS.txt">
   <li><a href="https://github.com/OctoMap/octomap/tags">Download source packages</a></li>	
   <li><a href="https://github.com/OctoMap/octomap/wiki/Compilation-and-Installation-of-OctoMap">Installation instructions</a></li>
   <li><a href="http://www.ros.org/wiki/octomap">OctoMap in ROS</a></li>	
-  <li><a href="http://octomap.github.com/octomap/doc/">Online API documentation (doxygen)</a></li>
-  <li><a href="http://groups.google.com/group/octomap">Mailing list</a> for support and announcements (Google Groups)</li>
+  <li><a href="https://octomap.github.com/octomap/doc/">Online API documentation (doxygen)</a></li>
+  <li><a href="https://groups.google.com/group/octomap">Mailing list</a> for support and announcements (Google Groups)</li>
   <li><a href="https://github.com/OctoMap/octomap/issues">Issue tracker</a> for bugs and feature requests</li>
   <li><a href="https://github.com/OctoMap/octomap/wiki/Importing-Data-into-OctoMap">Importing data instructions</a></li>
 	
@@ -106,55 +106,55 @@ all <a href="https://github.com/OctoMap/octomap/blob/devel/octomap/AUTHORS.txt">
 <h2>Example Projects</h2>
    <table border=0 width=680 class="youtube">
       <tr>                                         <!-- mapping  -->
-      <td class="youtube"><a href="http://www.youtube.com/v/7ZsxJzR14rc&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- campus map -->
-            <!-- <img src="http://img.youtube.com/vi/7ZsxJzR14rc/2.jpg"> -->
+      <td class="youtube"><a href="https://www.youtube.com/v/7ZsxJzR14rc&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- campus map -->
+            <!-- <img src="https://img.youtube.com/vi/7ZsxJzR14rc/2.jpg"> -->
             <img src="vi/campus.jpg" alt="Video thumb">
         </a></td>
 
-        <td class="youtube"><a href="http://www.youtube.com/v/O2TDNJuHMKo&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- fr 079 -->
-            <!-- <img src="http://img.youtube.com/vi/O2TDNJuHMKo/2.jpg"> -->
+        <td class="youtube"><a href="https://www.youtube.com/v/O2TDNJuHMKo&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- fr 079 -->
+            <!-- <img src="https://img.youtube.com/vi/O2TDNJuHMKo/2.jpg"> -->
             <img src="vi/079.jpg" alt="Video thumb">
         </a></td>                                
-        <td class="youtube"><a href="http://www.youtube.com/v/yp0f8-AKvDU&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=640;height=510"> <!-- object mapping -->
-        <img src="http://img.youtube.com/vi/yp0f8-AKvDU/3.jpg" alt="Video thumb">
+        <td class="youtube"><a href="https://www.youtube.com/v/yp0f8-AKvDU&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=640;height=510"> <!-- object mapping -->
+        <img src="https://img.youtube.com/vi/yp0f8-AKvDU/3.jpg" alt="Video thumb">
         </a></td>
         <!-- willow garage  -->
-        <td class="youtube"><a href="http://www.youtube.com/v/uiIi2rSKWAU&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=640;height=480"> <!-- nao localization -->
-        <img src="http://img.youtube.com/vi/uiIi2rSKWAU/2.jpg" alt="Video thumb">
+        <td class="youtube"><a href="https://www.youtube.com/v/uiIi2rSKWAU&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=640;height=480"> <!-- nao localization -->
+        <img src="https://img.youtube.com/vi/uiIi2rSKWAU/2.jpg" alt="Video thumb">
         </a></td>
-        <td class="youtube"><a href="http://www.youtube.com/v/9f32FmbtHCs&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=640;height=480"> <!-- color octomap demo -->
-            <!-- <img src="http://img.youtube.com/vi/9f32FmbtHCs/2.jpg"> -->
+        <td class="youtube"><a href="https://www.youtube.com/v/9f32FmbtHCs&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=640;height=480"> <!-- color octomap demo -->
+            <!-- <img src="https://img.youtube.com/vi/9f32FmbtHCs/2.jpg"> -->
             <img src="vi/cot.jpg" alt="Video thumb">
         </a></td>
       </tr>
 
       <tr> 
-      <td class="youtube"><a href="http://www.youtube.com/v/sot6gjj3SzU&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- willow 3d nav -->
+      <td class="youtube"><a href="https://www.youtube.com/v/sot6gjj3SzU&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- willow 3d nav -->
       <img src="vi/3dnav.jpg" alt="Video thumb">
-            <!-- <img src="http://img.youtube.com/vi/sot6gjj3SzU/3.jpg"> -->
+            <!-- <img src="https://img.youtube.com/vi/sot6gjj3SzU/3.jpg"> -->
         </a></td>
         <td class="youtube">
-<!-- <a href="http://www.youtube.com/v/hHF3pRWiP7o&rel=1&autoplay=1" rel="shadowbox;width=810;height=480"> -->
-<a href="http://www.youtube.com/v/25nnJ64ED5Q&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- willow octomap2 -->
-            <!-- <img src="http://img.youtube.com/vi/hHF3pRWiP7o/3.jpg"> -->
+<!-- <a href="https://www.youtube.com/v/hHF3pRWiP7o&rel=1&autoplay=1" rel="shadowbox;width=810;height=480"> -->
+<a href="https://www.youtube.com/v/25nnJ64ED5Q&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- willow octomap2 -->
+            <!-- <img src="https://img.youtube.com/vi/hHF3pRWiP7o/3.jpg"> -->
             <img src="vi/octomap2.jpg" alt="Video thumb">
         </a></td>    
         <!-- other freiburg projects -->
 
-        <td class="youtube"><a href="http://www.youtube.com/v/5o3ABX7xYJU&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=640;height=480"> <!-- rgbdslam -->
-            <!-- <img src="http://img.youtube.com/vi/5o3ABX7xYJU/2.jpg"> -->
+        <td class="youtube"><a href="https://www.youtube.com/v/5o3ABX7xYJU&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=640;height=480"> <!-- rgbdslam -->
+            <!-- <img src="https://img.youtube.com/vi/5o3ABX7xYJU/2.jpg"> -->
             <img src="vi/cot2.jpg" alt="Video thumb">
         </a></td>        
-        <td class="youtube"><a href="http://www.youtube.com/v/0sFyyKEoB4o&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- quadcopter mapping -->
-            <!-- <img src="http://img.youtube.com/vi/0sFyyKEoB4o/2.jpg"> -->
+        <td class="youtube"><a href="https://www.youtube.com/v/0sFyyKEoB4o&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- quadcopter mapping -->
+            <!-- <img src="https://img.youtube.com/vi/0sFyyKEoB4o/2.jpg"> -->
             <img src="vi/quad.jpg" alt="Video thumb">
         </a></td>
-        <td class="youtube"><a href="http://www.youtube.com/v/srcx7lPoIfw&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- 3D mapping Nao -->
-            <img src="http://img.youtube.com/vi/srcx7lPoIfw/2.jpg" alt="Video thumb"> 
+        <td class="youtube"><a href="https://www.youtube.com/v/srcx7lPoIfw&amp;rel=1&amp;autoplay=1" rel="shadowbox;width=810;height=480"> <!-- 3D mapping Nao -->
+            <img src="https://img.youtube.com/vi/srcx7lPoIfw/2.jpg" alt="Video thumb"> 
             <!--<img src="vi/coll.jpg" alt="Video thumb"> -->
         </a></td>
-        <!-- <td class="youtube"><a href="http://www.youtube.com/v/_rIAGKA6uS8"> --> <!-- wheelchair mapping -->
-        <!--     <img src="http://img.youtube.com/vi/_rIAGKA6uS8/2.jpg"> -->
+        <!-- <td class="youtube"><a href="https://www.youtube.com/v/_rIAGKA6uS8"> --> <!-- wheelchair mapping -->
+        <!--     <img src="https://img.youtube.com/vi/_rIAGKA6uS8/2.jpg"> -->
         <!-- </a></td> -->
       </tr>
 
@@ -218,7 +218,7 @@ projects A3-[MultiBot] and A8-[HumanoidSpace].</p>
 </div>
 <p>
     <a href="http://validator.w3.org/check?uri=referer"><img
-        src="http://www.w3.org/Icons/valid-html401"
+        src="https://www.w3.org/Icons/valid-html401"
         alt="Valid HTML 4.01 Transitional" height="31" width="88"></a>
   </p>
   


### PR DESCRIPTION
When using an extension such as HTTPS Everywhere the website itself gets loaded over HTTPS but the YouTube videos are blocked since they were loaded over HTTP. This changes the YouTube resources to HTTPS.